### PR TITLE
CS-6570: fix null character bug

### DIFF
--- a/text_extraction_system/text_extraction_system/data_extract/data_extract.py
+++ b/text_extraction_system/text_extraction_system/data_extract/data_extract.py
@@ -71,7 +71,8 @@ def extract_text_and_structure(pdf_fn: str,
             # see object structure in com.lexpredict.textextraction.dto.PDFPlainText
             pdfbox_res: Dict[str, Any] = msgpack.unpack(pages_f, raw=False)
 
-        text = pdfbox_res['text']
+        # Remove Null characters because of incompatibility with PostgreSQL
+        text = pdfbox_res['text'].replace("\x00", "")
         if len(text) == 0:
             pdf_coordinates = PDFCoordinates(char_bboxes_with_page_nums=pdfbox_res['charBBoxesWithPageNums'])
             text_struct = PlainTextStructure(title='',


### PR DESCRIPTION
List of all supported characters in PostgreSQL - https://www.postgresql.org/docs/11/multibyte.html

Most of issues with encoding are because of Null character, which is incompatible with PostgreSQL 11.5